### PR TITLE
Remove semicolon

### DIFF
--- a/getipintel.py
+++ b/getipintel.py
@@ -12,7 +12,7 @@ def checkIP(ip):
 	if (result.status_code != 200) or (float(result.content) < 0):
 		sys.stderr.write("An error occured while querying GetIPIntel")
 	if (float(result.content) > maxProbability):
-		return 1;
+		return 1
 	else:
-		return 0;
+		return 0
 


### PR DESCRIPTION
Python does not need semicolons anywhere unless you're placing multiple commands on a line